### PR TITLE
TableRowCounter

### DIFF
--- a/OpenXmlTemplator.Docx/CreatingDocumentDocx.cs
+++ b/OpenXmlTemplator.Docx/CreatingDocumentDocx.cs
@@ -57,6 +57,7 @@
                                     element: element,
                                     keyWordsHandler: keyWords,
                                     search: new SearchingKeyWordModelDocx(docxTemplatorModels.SearchModel),
+                                    builtInKeyWordsHandlers: docxTemplatorModels.BuiltInKeyWordsHandlers,
                                     toDelayedRemove: toDelayedRemove
                                     );
                             }
@@ -130,6 +131,7 @@
                                             element: element,
                                             keyWordsHandler: keyWords,
                                             search: new SearchingKeyWordModelDocx(docxTemplatorModels.SearchModel),
+                                            builtInKeyWordsHandlers: docxTemplatorModels.BuiltInKeyWordsHandlers,
                                             toDelayedRemove: toDelayedRemove
                                             );
                                     }

--- a/OpenXmlTemplator.Docx/Models/OuterModels/BuiltInKeyWordsHandlersDocx.cs
+++ b/OpenXmlTemplator.Docx/Models/OuterModels/BuiltInKeyWordsHandlersDocx.cs
@@ -1,0 +1,42 @@
+﻿using System.Globalization;
+
+namespace OpenXmlTemplator.Docx.Models.OuterModels
+{
+    /// <summary>
+    /// Настройки встроенных обработчиков ключевых слов, могу совпадать с пользовательскими, но имеют приоритет ниже
+    /// </summary>
+    public class BuiltInKeyWordsHandlersDocx
+    {
+        #region Счетчик строк в таблицах
+        /// <summary>
+        /// Обозначение счетчика строк в таблице
+        /// </summary>
+        public string TableRowCounter_Sign { get; init; } = "№";
+
+        /// <summary>
+        /// Стартовое значение счетчика строк в таблице
+        /// </summary>
+        public int TableRowCounter_StartValue { get; init; } = 1;
+
+        /// <summary>
+        /// Текущее значение счетчика строк
+        /// </summary>
+        internal int TableRowCounter_CurrentValue { get; set; }
+
+        /// <summary>
+        /// Нужно ли сбрасывать счетчик строк при завершении заполнения шаблонов-строк для каждого элемента таблицы(если true - 1,2,3,1,2,3 и т.д.)
+        /// </summary>
+        public bool TableRowCounter_ResetByTemplateList { get; set; } = false;
+
+        /// <summary>
+        /// Использовать слова вместо цифо
+        /// </summary>
+        public bool TableRowCounter_UseWords { get; set; }
+
+        /// <summary>
+        /// Культура для перевода цифр в строку
+        /// </summary>
+        public CultureInfo TableRowCounter_WordsCulture { get; set; } = CultureInfo.CurrentCulture;
+        #endregion
+    }
+}

--- a/OpenXmlTemplator.Docx/Models/OuterModels/DocumentModelDocx.cs
+++ b/OpenXmlTemplator.Docx/Models/OuterModels/DocumentModelDocx.cs
@@ -22,6 +22,11 @@
         /// </summary>
         public SearchModelDocx SearchModel { get; }
 
+        /// <summary>
+        /// Настройки встроенных обработчиков ключевых слов, могу совпадать с пользовательскими, но имеют приоритет ниже
+        /// </summary>
+        public BuiltInKeyWordsHandlersDocx BuiltInKeyWordsHandlers { get; init; } = new BuiltInKeyWordsHandlersDocx();
+
         private DocumentModelDocx(SearchModelDocx searchModel)
         {
             SearchModel = searchModel;

--- a/OpenXmlTemplator.Docx/OpenXmlTemplator.Docx.csproj
+++ b/OpenXmlTemplator.Docx/OpenXmlTemplator.Docx.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>1.0.5</Version>
+		<Version>1.1.0</Version>
 
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		
@@ -18,4 +18,8 @@
 		<PackageDescription>Templator for docx, more details at GitHub</PackageDescription>
 		<RepositoryUrl>https://github.com/Bread57/OpenXmlTemplator</RepositoryUrl>
 	</PropertyGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="Humanizer" Version="2.14.1" />
+	</ItemGroup>
 </Project>

--- a/OpenXmlTemplator.Tests/DocxTests.cs
+++ b/OpenXmlTemplator.Tests/DocxTests.cs
@@ -166,7 +166,7 @@ namespace OpenXmlTemplator.Tests
                 Directory.CreateDirectory(templatesDirectory);
             }
 
-            using FileStream readStream = new(Path.Combine(templatesDirectory, "TestTable.docx"), FileMode.Open);
+            using FileStream readStream = new(Path.Combine(templatesDirectory, "TestTable.docx"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
             KeyWordsHandlerModelDocx keyWords = new(keyWordHandlerNotFoundMessage: "Not found")
             {
@@ -194,7 +194,6 @@ namespace OpenXmlTemplator.Tests
                                 KeyWordsToReplace = new Dictionary<string, string>
                                 {
                                     //1 row
-                                    { "1","NONINFRINGEMENT"},
                                     { "2","IN"},
                                     { "3","NO"},
                                     { "4","EVENT"},
@@ -203,7 +202,6 @@ namespace OpenXmlTemplator.Tests
                                     { "7","AUTHORS"},
 
                                     //2 row
-                                    { "8","8888888888"},
                                     { "9","999999999"},
                                     { "10","1010101001"},
                                     { "11","1111111111111"},
@@ -212,7 +210,6 @@ namespace OpenXmlTemplator.Tests
                                     { "14","14141414114141414414"},
 
                                     //3 row
-                                    { "a","aaaaaaaaaaaaaaa"},
                                     { "u","uuuuuuuuu"},
                                     { "h","hhhhhhhh"},
                                     { "l","iiiiiii"},
@@ -226,7 +223,6 @@ namespace OpenXmlTemplator.Tests
                                 KeyWordsToReplace = new Dictionary<string, string>
                                 {
                                     //1 row
-                                    { "1","OR"},
                                     { "2","COPYRIGHT"},
                                     { "3","HOLDERS"},
                                     { "4","BE"},
@@ -235,7 +231,6 @@ namespace OpenXmlTemplator.Tests
                                     { "7","ANY"},
 
                                     //2 row
-                                    { "8","+8888888888"},
                                     { "9","+999999999"},
                                     { "10","+1010101001"},
                                     { "11","+1111111111111"},
@@ -244,7 +239,6 @@ namespace OpenXmlTemplator.Tests
                                     { "14","+14141414114141414414"},
 
                                     //3 row
-                                    { "a","*aaaaaaaaaaaaaaa"},
                                     { "u","*uuuuuuuuu"},
                                     { "h","*hhhhhhhh"},
                                     { "l","*iiiiiii"},
@@ -258,7 +252,6 @@ namespace OpenXmlTemplator.Tests
                                 KeyWordsToReplace = new Dictionary<string, string>
                                 {
                                     //1 row
-                                    { "1","CLAIM"},
                                     { "2","DAMAGES"},
                                     { "3","OR"},
                                     { "4","OTHER "},
@@ -267,7 +260,6 @@ namespace OpenXmlTemplator.Tests
                                     { "7","$%^&"},
 
                                      //2 row
-                                    { "8","-8888888888"},
                                     { "9","-999999999"},
                                     { "10","-1010101001"},
                                     { "11","-1111111111111"},
@@ -276,7 +268,6 @@ namespace OpenXmlTemplator.Tests
                                     { "14","-14141414114141414414"},
 
                                     //3 row
-                                    { "a","%aaaaaaaaaaaaaaa"},
                                     { "u","%uuuuuuuuu"},
                                     { "h","%hhhhhhhh"},
                                     { "l","%iiiiiii"},
@@ -292,7 +283,16 @@ namespace OpenXmlTemplator.Tests
 
             SearchModelDocx searchModel = new(startingKeys: ['[', '#'], endingKeys: ['#', ']']);
 
-            DocumentModelDocx model = new(inStream: readStream, keyWords: keyWords, searchModel: searchModel);
+            DocumentModelDocx model = new(inStream: readStream, keyWords: keyWords, searchModel: searchModel)
+            {
+                BuiltInKeyWordsHandlers = new BuiltInKeyWordsHandlersDocx
+                {
+                    TableRowCounter_Sign = "№",
+                    TableRowCounter_ResetByTemplateList = false,
+                    TableRowCounter_UseWords = true,
+                    TableRowCounter_WordsCulture = new System.Globalization.CultureInfo("en-US")
+                }
+            };
 
             string resultsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "DocxTestResults");
 


### PR DESCRIPTION
Built-in handlers, one for now (optional, if not necessary - you can skip it):

Row counter for tables - allows you not to manually specify the number for each table row, it is enough to specify the keyword of this handler on the template, supports the ability to translate numbers into words (like the first, second, etc.).